### PR TITLE
Improve endpoint page readability and uppercase nav labels

### DIFF
--- a/web/src/pages/endpoint/[slug].astro
+++ b/web/src/pages/endpoint/[slug].astro
@@ -392,29 +392,34 @@ if(endpoint.riotRequirements !== undefined) {
 
 <style>
 .ep-main {
-    padding: 40px 48px;
-    max-width: 860px;
+    padding: 40px 56px;
+    max-width: 1100px;
     margin: 0 auto;
     width: 100%;
 }
 
 .ep-header {
-    margin-bottom: 20px;
-    padding-bottom: 20px;
+    margin-bottom: 24px;
+    padding-bottom: 24px;
     border-bottom: 1px solid var(--border);
 }
 
 .ep-title {
-    font-size: 24px;
+    font-size: 36px;
+    font-family: var(--display);
+    font-weight: 800;
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 12px;
     flex-wrap: wrap;
-    text-transform: uppercase;
+    letter-spacing: -0.5px;
+    color: var(--text);
 }
 
 :global(.ep-method) {
-    font-size: 14px !important;
+    font-size: 16px !important;
+    font-family: var(--mono);
+    font-weight: 700;
 }
 
 .ep-url {
@@ -423,11 +428,11 @@ if(endpoint.riotRequirements !== undefined) {
     border: 1px solid var(--border);
     border-left: 3px solid var(--accent);
     border-radius: 6px;
-    padding: 12px 16px;
-    font-size: 13px;
+    padding: 14px 18px;
+    font-size: 14px;
     word-break: break-all;
     color: #c8c8c8;
-    margin-bottom: 24px;
+    margin-bottom: 28px;
 }
 
 :global(.ep-url a) {
@@ -437,23 +442,23 @@ if(endpoint.riotRequirements !== undefined) {
 :global(.ep-url a:hover) { text-decoration: underline; }
 
 .ep-description {
-    margin-bottom: 28px;
-    font-size: 14px;
-    color: #bbb;
-    line-height: 1.8;
+    margin-bottom: 32px;
+    font-size: 16px;
+    color: #ccc;
+    line-height: 1.9;
 }
 
 .ep-section {
-    margin-top: 28px;
+    margin-top: 32px;
 }
 
 .ep-section-title {
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 2px;
     color: #777;
-    margin-bottom: 12px;
+    margin-bottom: 14px;
     padding-bottom: 8px;
     border-bottom: 1px solid var(--border);
 }
@@ -481,10 +486,10 @@ if(endpoint.riotRequirements !== undefined) {
 }
 
 .ep-var-desc {
-    font-size: 13px;
+    font-size: 15px;
     color: #aaa;
     margin-top: 6px;
-    line-height: 1.7;
+    line-height: 1.8;
 }
 
 :global(.ep-var-desc a) { color: var(--accent); }
@@ -503,11 +508,11 @@ if(endpoint.riotRequirements !== undefined) {
 }
 
 :global(.astro-code) {
-    padding: 14px 16px !important;
+    padding: 16px 18px !important;
     border-radius: 0 0 6px 6px !important;
     border: 1px solid var(--border) !important;
     border-top: none !important;
-    font-size: 12px !important;
+    font-size: 13px !important;
 }
 
 .schema-tabs {


### PR DESCRIPTION
## Summary

- Заголовок эндпоинта: 36px шрифт Syne, читаемый регистр
- Ширина контента расширена: 860px → 1100px
- Основной текст увеличен: 14px → 16px
- Описания переменных: 13px → 15px
- Код-блоки: 12px → 13px
- Названия эндпоинтов в сайдбаре — всегда в КАПСЕ

https://claude.ai/code/session_01NJKUFsqSxLPjTSCeoXGJqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJKUFsqSxLPjTSCeoXGJqJ)_