### PR TITLE
Add Replays category with Match Replay Info endpoint

### DIFF
--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -81,6 +81,7 @@ import {riotClientConfigEndpoint} from './endpoints/auth/RiotClientConfig'
 import {partyDisableCodeEndpoint} from './endpoints/party/PartyDisableCode'
 import {partyGenerateCodeEndpoint} from './endpoints/party/PartyGenerateCode'
 import {partyJoinByCodeEndpoint} from './endpoints/party/PartyJoinByCode'
+import {matchReplayInfoEndpoint} from './endpoints/replays/MatchReplayInfo'
 
 export const endpoints = {
     fetchContentEndpoint,
@@ -173,5 +174,7 @@ export const endpoints = {
     playerInfoEndpoint,
     riotGeoEndpoint,
     pasTokenEndpoint,
-    riotClientConfigEndpoint
+    riotClientConfigEndpoint,
+
+    matchReplayInfoEndpoint
 }

--- a/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
+++ b/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
@@ -1,0 +1,27 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+import {matchIDSchema, playerUUIDSchema} from '../../commonTypes'
+
+export const matchReplayInfoEndpoint = {
+    name: 'Match Replay Info',
+    description: 'Get download URLs for match replay files. Supports fetching multiple matches at once by repeating the `id` query parameter.\n\n`{type}` can be:\n- `SUMMARY` — returns signed URLs to JSON files with match data\n- `REPLAY` — returns signed URLs to `.vrf` replay files playable in the Valorant client\n\nThe `{puuid}` must be your own or a friend\'s — otherwise access will be denied.',
+    queryName: 'MatchHistoryQuery_GetMatchFileUrls',
+    category: 'Replays',
+    type: 'other',
+    suffix: 'https://{region}c1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}',
+    riotRequirements: {
+        token: true,
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
+    },
+    variables: new Map([
+        ['type', z.enum(['SUMMARY', 'REPLAY']).describe('`SUMMARY` returns match data JSON URLs, `REPLAY` returns `.vrf` replay file URLs')],
+    ]),
+    responses: {
+        '200': z.object({
+            total: z.number().describe('Number of matches returned'),
+            matchFileUrlsMap: z.record(matchIDSchema, z.string().url().describe('Signed CloudFront URL, expires after a short time'))
+        })
+    }
+} as const satisfies ValorantEndpoint


### PR DESCRIPTION
## Summary

Новая категория **Replays** с эндпоинтом **Match Replay Info**:

- `GET {region}c1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}`
- `type=SUMMARY` — возвращает подписанные CloudFront URL на JSON-файлы с данными матча
- `type=REPLAY` — возвращает подписанные URL на `.vrf` файлы реплея для клиента
- Поддерживает несколько матчей через повторяющийся параметр `?id=`
- `{puuid}` должен быть своим или друга (иначе нет доступа)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJKUFsqSxLPjTSCeoXGJqJ)_