### PR TITLE
Add Replays category with Match Replay Info endpoint

### DIFF
--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -81,7 +81,6 @@ import {riotClientConfigEndpoint} from './endpoints/auth/RiotClientConfig'
 import {partyDisableCodeEndpoint} from './endpoints/party/PartyDisableCode'
 import {partyGenerateCodeEndpoint} from './endpoints/party/PartyGenerateCode'
 import {partyJoinByCodeEndpoint} from './endpoints/party/PartyJoinByCode'
-import {matchReplayInfoEndpoint} from './endpoints/replays/MatchReplayInfo'
 
 export const endpoints = {
     fetchContentEndpoint,
@@ -174,7 +173,5 @@ export const endpoints = {
     playerInfoEndpoint,
     riotGeoEndpoint,
     pasTokenEndpoint,
-    riotClientConfigEndpoint,
-
-    matchReplayInfoEndpoint
+    riotClientConfigEndpoint
 }

--- a/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
+++ b/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
@@ -10,10 +10,7 @@ export const matchReplayInfoEndpoint = {
     type: 'other',
     suffix: 'https://euc1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}',
     riotRequirements: {
-        token: true,
-        entitlement: true,
-        clientPlatform: true,
-        clientVersion: true
+        token: true
     },
     variables: new Map<string, z.ZodTypeAny>([
         ['type', z.enum(['SUMMARY', 'REPLAY']).describe('`SUMMARY` returns match data JSON URLs, `REPLAY` returns `.vrf` replay file URLs')],

--- a/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
+++ b/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
@@ -8,7 +8,7 @@ export const matchReplayInfoEndpoint = {
     queryName: 'MatchHistoryQuery_GetMatchFileUrls',
     category: 'Replays',
     type: 'other',
-    suffix: 'https://{region}c1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}',
+    suffix: 'https://euc1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}',
     riotRequirements: {
         token: true,
         entitlement: true,

--- a/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
+++ b/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
@@ -8,15 +8,16 @@ export const matchReplayInfoEndpoint = {
     queryName: 'MatchHistoryQuery_GetMatchFileUrls',
     category: 'Replays',
     type: 'other',
-    suffix: 'https://euc1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}',
+    suffix: 'https://euc1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}',
     riotRequirements: {
         token: true,
         entitlement: true,
         clientPlatform: true,
         clientVersion: true
     },
-    variables: new Map([
+    variables: new Map<string, z.ZodTypeAny>([
         ['type', z.enum(['SUMMARY', 'REPLAY']).describe('`SUMMARY` returns match data JSON URLs, `REPLAY` returns `.vrf` replay file URLs')],
+        ['match id', matchIDSchema.describe('A match ID. Can be repeated multiple times to fetch several matches in one request. Match IDs can be obtained from the [GET Match History] endpoint.')],
     ]),
     responses: {
         '200': z.object({

--- a/valorant-api-types/src/index.ts
+++ b/valorant-api-types/src/index.ts
@@ -87,6 +87,12 @@ export * from './endpoints/auth/RiotGeo'
 export * from './endpoints/auth/PASToken'
 export * from './endpoints/auth/RiotClientConfig'
 
+export * from './endpoints/pvp/PlayerSession'
+export * from './endpoints/store/Storefront2'
+export * from './endpoints/store/CreateOrder'
+export * from './endpoints/store/GetOrder'
+export * from './endpoints/replays/MatchReplayInfo'
+
 export * from './endpoints'
 export * from './commonTypes'
 export * from './ValorantEndpoint'

--- a/web/src/types/AugmentedValorantEndpoint.ts
+++ b/web/src/types/AugmentedValorantEndpoint.ts
@@ -1,5 +1,5 @@
 import type { ValorantEndpoint } from "valorant-api-types";
-import { endpoints as existingEndpoints } from "valorant-api-types";
+import { endpoints as existingEndpoints, matchReplayInfoEndpoint } from "valorant-api-types";
 import { z } from "zod";
 
 export type AugmentedValorantEndpoint = Omit<ValorantEndpoint, 'method'> & {
@@ -37,6 +37,7 @@ export const endpoints: {[key: string]: AugmentedValorantEndpoint} = {
             ['chat server port', z.string().describe('The chat server port from the [GET Riot Client Config]. Only observed as `5223`')]
         ])
     },
+    matchReplayInfoEndpoint: matchReplayInfoEndpoint as unknown as AugmentedValorantEndpoint,
     ...(existingEndpoints as unknown as {[key: string]: AugmentedValorantEndpoint}),
     localWebSocketEndpoint: {
         name: 'Local WebSocket',


### PR DESCRIPTION
## Summary

- Новая категория **Replays** (после XMPP в сайдбаре)
- Эндпоинт **Match Replay Info**: `GET https://euc1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}`
- `type=SUMMARY` — signed URL на JSON с данными матча
- `type=REPLAY` — signed URL на `.vrf` файл реплея
- Только `Authorization` header
- `{puuid}` должен быть своим или друга

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJKUFsqSxLPjTSCeoXGJqJ)_