### PR TITLE
Add Active Future Interventions endpoint

### DIFF
--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -8,6 +8,7 @@ import {matchDetailsEndpoint} from './endpoints/pvp/MatchDetails'
 import {competitiveUpdatesEndpoint} from './endpoints/pvp/CompetitiveUpdates'
 import {leaderboardEndpoint} from './endpoints/pvp/Leaderboard'
 import {penaltiesEndpoint} from './endpoints/pvp/Penalties'
+import {activeFutureInterventionsEndpoint} from './endpoints/pvp/ActiveFutureInterventions'
 import {itemUpgradesEndpoint} from './endpoints/contracts/ItemUpgrades'
 import {configEndpoint} from './endpoints/pvp/Config'
 import {partyEndpoint} from './endpoints/party/Party'
@@ -93,6 +94,7 @@ export const endpoints = {
     competitiveUpdatesEndpoint,
     leaderboardEndpoint,
     penaltiesEndpoint,
+    activeFutureInterventionsEndpoint,
     configEndpoint,
     nameServiceEndpoint,
     playerSessionEndpoint,

--- a/valorant-api-types/src/endpoints/pvp/ActiveFutureInterventions.ts
+++ b/valorant-api-types/src/endpoints/pvp/ActiveFutureInterventions.ts
@@ -1,0 +1,42 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+import {playerUUIDSchema} from '../../commonTypes'
+
+const interventionSchema = z.object({
+    InterventionName: z.string(),
+    Expiry: z.string(),
+    IssuingTime: z.string(),
+    OriginInfraction: z.string()
+})
+
+export const activeFutureInterventionsEndpoint = {
+    name: 'Active Future Interventions',
+    description: 'Get active and upcoming behavioral interventions (penalties) for the player, grouped by behavior category such as AFK or queue dodging.',
+    queryName: 'Restrictions_FetchActiveFutureInterventions',
+    category: 'PVP Endpoints',
+    type: 'pd',
+    suffix: 'restrictions/v1/activeFutureInterventions',
+    riotRequirements: {
+        token: true,
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
+    },
+    responses: {
+        '200': z.object({
+            Subject: playerUUIDSchema,
+            InterventionsByCategory: z.array(z.object({
+                BehaviorCategory: z.string().describe('e.g. "PARTICIPATION"'),
+                BehaviorRatingName: z.string().describe('e.g. "afk"'),
+                LastRatingReduction: z.string(),
+                ActiveInterventions: z.array(interventionSchema),
+                NextInterventionNames: z.array(z.string()),
+                AppliedInfractions: z.record(z.string(), z.object({
+                    InfractionName: z.string(),
+                    Severity: z.string().describe('e.g. "MODERATE"'),
+                    AppliedInterventions: z.array(interventionSchema)
+                }))
+            }))
+        })
+    }
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/index.ts
+++ b/valorant-api-types/src/index.ts
@@ -88,6 +88,7 @@ export * from './endpoints/auth/PASToken'
 export * from './endpoints/auth/RiotClientConfig'
 
 export * from './endpoints/pvp/PlayerSession'
+export * from './endpoints/pvp/ActiveFutureInterventions'
 export * from './endpoints/store/Storefront2'
 export * from './endpoints/store/CreateOrder'
 export * from './endpoints/store/GetOrder'


### PR DESCRIPTION
## Summary

Новый эндпоинт **Active Future Interventions** рядом с Penalties:

- `GET https://pd.{shard}.a.pvp.net/restrictions/v1/activeFutureInterventions`
- Возвращает активные поведенческие санкции по категориям (AFK, dodge и т.д.)
- Включает активные интервенции, применённые нарушения и следующие санкции

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJKUFsqSxLPjTSCeoXGJqJ)_