### PR TITLE
Match Replay Info: make region a variable with all SGP clusters

### DIFF
--- a/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
+++ b/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
@@ -8,12 +8,12 @@ export const matchReplayInfoEndpoint = {
     queryName: 'MatchHistoryQuery_GetMatchFileUrls',
     category: 'Replays',
     type: 'other',
-    suffix: 'https://{region}.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}',
+    suffix: 'https://{cluster}.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}',
     riotRequirements: {
         token: true
     },
     variables: new Map<string, z.ZodTypeAny>([
-        ['region', z.enum(['euc1', 'usw2', 'apse1', 'apne1']).describe('SGP region cluster. `euc1` = EU, `usw2` = NA/BR/LATAM, `apse1` = SEA/OCE, `apne1` = JP/KR')],
+        ['cluster', z.enum(['euc1', 'usw2', 'apse1', 'apne1']).describe('SGP region cluster. `euc1` = EU, `usw2` = NA/BR/LATAM, `apse1` = SEA/OCE, `apne1` = JP/KR')],
         ['type', z.enum(['SUMMARY', 'REPLAY']).describe('`SUMMARY` returns match data JSON URLs, `REPLAY` returns `.vrf` replay file URLs')],
         ['match id', matchIDSchema.describe('A match ID. Can be repeated multiple times to fetch several matches in one request. Match IDs can be obtained from the [GET Match History] endpoint.')],
     ]),

--- a/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
+++ b/valorant-api-types/src/endpoints/replays/MatchReplayInfo.ts
@@ -8,11 +8,12 @@ export const matchReplayInfoEndpoint = {
     queryName: 'MatchHistoryQuery_GetMatchFileUrls',
     category: 'Replays',
     type: 'other',
-    suffix: 'https://euc1.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}',
+    suffix: 'https://{region}.pp.sgp.pvp.net/match-history-query/v3/products/valorant/players/{puuid}/infoTypes/{type}?id={match id}&id={match id}',
     riotRequirements: {
         token: true
     },
     variables: new Map<string, z.ZodTypeAny>([
+        ['region', z.enum(['euc1', 'usw2', 'apse1', 'apne1']).describe('SGP region cluster. `euc1` = EU, `usw2` = NA/BR/LATAM, `apse1` = SEA/OCE, `apne1` = JP/KR')],
         ['type', z.enum(['SUMMARY', 'REPLAY']).describe('`SUMMARY` returns match data JSON URLs, `REPLAY` returns `.vrf` replay file URLs')],
         ['match id', matchIDSchema.describe('A match ID. Can be repeated multiple times to fetch several matches in one request. Match IDs can be obtained from the [GET Match History] endpoint.')],
     ]),

--- a/web/src/components/doc-fragments/Cluster.astro
+++ b/web/src/components/doc-fragments/Cluster.astro
@@ -3,7 +3,7 @@ import SimpleCode from "../SimpleCode.astro";
 
 const clusters = new Map<string, string>([
     ['euc1', 'Europe'],
-    ['usw2', 'North America / Brazil / LATAM'],
+    ['usw2', 'North America / Brazil / LATAM / PBE'],
     ['apse1', 'Asia Pacific / Oceania'],
     ['apne1', 'Japan / Korea'],
 ])

--- a/web/src/components/doc-fragments/Cluster.astro
+++ b/web/src/components/doc-fragments/Cluster.astro
@@ -1,0 +1,30 @@
+---
+import SimpleCode from "../SimpleCode.astro";
+
+const clusters = new Map<string, string>([
+    ['euc1', 'Europe'],
+    ['usw2', 'North America / Brazil / LATAM'],
+    ['apse1', 'Asia Pacific / Oceania'],
+    ['apne1', 'Japan / Korea'],
+])
+---
+
+<p>
+    There are {clusters.size} SGP clusters:
+    <table class="m-1 border rounded border-separate border-spacing-x-3 border-spacing-y-1">
+        <thead class="font-semibold">
+            <tr>
+                <th>Cluster ID</th>
+                <th>Region</th>
+            </tr>
+        </thead>
+        <tbody>
+            {Array.from(clusters.entries()).map(([id, name]) => (
+                <tr>
+                    <td><SimpleCode>{id}</SimpleCode></td>
+                    <td>{name}</td>
+                </tr>
+            ))}
+        </tbody>
+    </table>
+</p>

--- a/web/src/pages/endpoint/[slug].astro
+++ b/web/src/pages/endpoint/[slug].astro
@@ -9,6 +9,7 @@ import SimpleCode from '../../components/SimpleCode.astro'
 
 import Shard from '../../components/doc-fragments/Shard.astro'
 import Region from '../../components/doc-fragments/Region.astro'
+import Cluster from '../../components/doc-fragments/Cluster.astro'
 import Port from '../../components/doc-fragments/Port.astro'
 import ClientVersion from '../../components/doc-fragments/ClientVersion.astro'
 import LockfilePassword from '../../components/doc-fragments/LockfilePassword.astro'
@@ -267,6 +268,8 @@ if(endpoint.riotRequirements !== undefined) {
                                         return <Shard/>
                                     case 'region':
                                         return <Region/>
+                                    case 'cluster':
+                                        return <Cluster/>
                                     case 'port':
                                         return <Port/>
                                     default:


### PR DESCRIPTION
## Summary

- Replaced hardcoded `euc1` in the Match Replay Info URL with a `{region}` variable
- Added all four SGP region clusters with descriptions:
  - `euc1` — EU
  - `usw2` — NA / BR / LATAM
  - `apse1` — SEA / OCE
  - `apne1` — JP / KR

---