### PR TITLE
Fix missing X-Riot-ClientPlatform and X-Riot-ClientVersion headers in Create Order and Get Order

### DIFF
--- a/valorant-api-types/src/endpoints/store/CreateOrder.ts
+++ b/valorant-api-types/src/endpoints/store/CreateOrder.ts
@@ -12,7 +12,9 @@ export const createOrderEndpoint = {
     suffix: 'store/v1/order/',
     riotRequirements: {
         token: true,
-        entitlement: true
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
     },
     body: z.object({
         XID: z.string().length(36).describe('Unique Riot identifier (36 characters, UUID format)'),

--- a/valorant-api-types/src/endpoints/store/GetOrder.ts
+++ b/valorant-api-types/src/endpoints/store/GetOrder.ts
@@ -16,7 +16,9 @@ export const getOrderEndpoint = {
     suffix: 'store/v1/order/{order id}',
     riotRequirements: {
         token: true,
-        entitlement: true
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
     },
     responses: {
         '200': z.object({


### PR DESCRIPTION
## Summary

- Added `clientPlatform: true` and `clientVersion: true` to `riotRequirements` in Create Order and Get Order endpoints
- Consistent with all other store endpoints (Storefront, Prices, Wallet, Owned Items)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJKUFsqSxLPjTSCeoXGJqJ)_