### PR TITLE
feat: add Esports category and Premier endpoints

### DIFF
--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -95,6 +95,7 @@ import {premierSeasonActiveEndpoint} from './endpoints/premier/PremierSeasonActi
 import {premierConferencesEndpoint} from './endpoints/premier/PremierConferences'
 import {premierRosterEndpoint} from './endpoints/premier/PremierRoster'
 import {esportsUpcomingMatchesEndpoint} from './endpoints/esports/EsportsUpcomingMatches'
+import {esportsMatchesEndpoint} from './endpoints/esports/EsportsMatches'
 import {premierRosterMatchHistoryEndpoint} from './endpoints/premier/PremierRosterMatchHistory'
 import {premierRosterPublicInfoEndpoint} from './endpoints/premier/PremierRosterPublicInfo'
 import {premierRosterSetCustomizationEndpoint} from './endpoints/premier/PremierRosterSetCustomization'
@@ -168,6 +169,7 @@ export const endpoints = {
     premierSeasonActiveEndpoint,
     premierConferencesEndpoint,
     esportsUpcomingMatchesEndpoint,
+    esportsMatchesEndpoint,
 
     premierRosterEndpoint,
     premierRosterMatchHistoryEndpoint,

--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -96,6 +96,7 @@ import {premierConferencesEndpoint} from './endpoints/premier/PremierConferences
 import {premierRosterEndpoint} from './endpoints/premier/PremierRoster'
 import {premierRosterMatchHistoryEndpoint} from './endpoints/premier/PremierRosterMatchHistory'
 import {premierRosterPublicInfoEndpoint} from './endpoints/premier/PremierRosterPublicInfo'
+import {premierRosterSetCustomizationEndpoint} from './endpoints/premier/PremierRosterSetCustomization'
 
 export const endpoints = {
     fetchContentEndpoint,
@@ -168,6 +169,7 @@ export const endpoints = {
     premierRosterEndpoint,
     premierRosterMatchHistoryEndpoint,
     premierRosterPublicInfoEndpoint,
+    premierRosterSetCustomizationEndpoint,
 
     itemUpgradesEndpoint,
     contractsEndpoint,

--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -95,6 +95,7 @@ import {premierSeasonActiveEndpoint} from './endpoints/premier/PremierSeasonActi
 import {premierConferencesEndpoint} from './endpoints/premier/PremierConferences'
 import {premierRosterEndpoint} from './endpoints/premier/PremierRoster'
 import {premierRosterMatchHistoryEndpoint} from './endpoints/premier/PremierRosterMatchHistory'
+import {premierRosterPublicInfoEndpoint} from './endpoints/premier/PremierRosterPublicInfo'
 
 export const endpoints = {
     fetchContentEndpoint,
@@ -166,6 +167,7 @@ export const endpoints = {
     premierConferencesEndpoint,
     premierRosterEndpoint,
     premierRosterMatchHistoryEndpoint,
+    premierRosterPublicInfoEndpoint,
 
     itemUpgradesEndpoint,
     contractsEndpoint,

--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -94,6 +94,7 @@ import {premierSeasonsEndpoint} from './endpoints/premier/PremierSeasons'
 import {premierSeasonActiveEndpoint} from './endpoints/premier/PremierSeasonActive'
 import {premierConferencesEndpoint} from './endpoints/premier/PremierConferences'
 import {premierRosterEndpoint} from './endpoints/premier/PremierRoster'
+import {esportsUpcomingMatchesEndpoint} from './endpoints/esports/EsportsUpcomingMatches'
 import {premierRosterMatchHistoryEndpoint} from './endpoints/premier/PremierRosterMatchHistory'
 import {premierRosterPublicInfoEndpoint} from './endpoints/premier/PremierRosterPublicInfo'
 import {premierRosterSetCustomizationEndpoint} from './endpoints/premier/PremierRosterSetCustomization'
@@ -166,6 +167,8 @@ export const endpoints = {
     premierSeasonsEndpoint,
     premierSeasonActiveEndpoint,
     premierConferencesEndpoint,
+    esportsUpcomingMatchesEndpoint,
+
     premierRosterEndpoint,
     premierRosterMatchHistoryEndpoint,
     premierRosterPublicInfoEndpoint,

--- a/valorant-api-types/src/endpoints/esports/EsportsMatches.ts
+++ b/valorant-api-types/src/endpoints/esports/EsportsMatches.ts
@@ -1,0 +1,57 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z, ZodType} from 'zod'
+
+const destinationSchema = z.object({
+    StructuralID: z.string(),
+    Type: z.string().describe('e.g. "decisionPoint", "standing"'),
+    Slot: z.number()
+})
+
+const matchTeamSchema = z.object({
+    TeamID: z.string(),
+    OriginStructuralID: z.string(),
+    OriginType: z.string(),
+    OriginSlot: z.number(),
+    Result: z.string().describe('e.g. "win", "loss", or empty string if unstarted'),
+    GameWins: z.number()
+})
+
+const matchSchema = z.object({
+    ID: z.string(),
+    LeagueID: z.string(),
+    TournamentID: z.string(),
+    StageID: z.string(),
+    StageName: z.string(),
+    StructuralID: z.string(),
+    StartTime: z.string().describe('ISO 8601 date string'),
+    State: z.string().describe('e.g. "unstarted", "inprogress", "completed"'),
+    Destinations: z.record(z.string(), destinationSchema).describe('Map of outcome ("Win", "Loss") to destination'),
+    MatchTeams: z.array(matchTeamSchema),
+    Streams: z.array(z.unknown())
+})
+
+export const esportsMatchesEndpoint = {
+    name: 'Matches',
+    description: 'Get esports match details by match IDs.',
+    queryName: 'Esports_GetMatches',
+    category: 'Esports',
+    type: 'pd',
+    method: 'POST',
+    suffix: 'esports-service/v2/matches',
+    query: new Map([
+        ['locale', z.string().optional().describe('Locale for localized names, e.g. "ru-RU", "en-US"') as ZodType],
+        ['sport', z.string().optional().describe('Sport identifier, always "val" for Valorant') as ZodType],
+    ]),
+    riotRequirements: {
+        token: true,
+        entitlement: true
+    },
+    body: z.object({
+        MATCHIDS: z.array(z.string()).describe('List of match IDs to fetch')
+    }),
+    responses: {
+        '200': z.object({
+            Matches: z.array(matchSchema)
+        })
+    }
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/esports/EsportsUpcomingMatches.ts
+++ b/valorant-api-types/src/endpoints/esports/EsportsUpcomingMatches.ts
@@ -1,5 +1,5 @@
 import {ValorantEndpoint} from '../../ValorantEndpoint'
-import {z} from 'zod'
+import {z, ZodType} from 'zod'
 
 const teamSchema = z.object({
     ID: z.string(),
@@ -41,6 +41,11 @@ export const esportsUpcomingMatchesEndpoint = {
     category: 'Esports',
     type: 'pd',
     suffix: 'esports-service/v2/upcomingMatches',
+    query: new Map([
+        ['leagueID', z.string().describe('Comma-separated list of league IDs. Default VCT leagues: 107254585505459304,109940824119741550,109974795266458277,106109559530232966,109974804058058602,111691194187846945,109222784797127274') as ZodType],
+        ['locale', z.string().optional().describe('Locale for localized names, e.g. "ru-RU", "en-US"') as ZodType],
+        ['sport', z.string().optional().describe('Sport identifier, always "val" for Valorant') as ZodType],
+    ]),
     riotRequirements: {
         token: true,
         entitlement: true

--- a/valorant-api-types/src/endpoints/esports/EsportsUpcomingMatches.ts
+++ b/valorant-api-types/src/endpoints/esports/EsportsUpcomingMatches.ts
@@ -1,0 +1,57 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+
+const teamSchema = z.object({
+    ID: z.string(),
+    Name: z.string(),
+    Code: z.string(),
+    BaseImageURL: z.string(),
+    HighResImageURL: z.string(),
+    LowResImageURL: z.string(),
+    HomeLeagueID: z.string(),
+    TeamMemberIDs: z.array(z.string()).nullable(),
+    BundleID: z.string(),
+    BundleDataAssetID: z.string(),
+    DataAssetID: z.string()
+})
+
+const leagueSchema = z.object({
+    ID: z.string(),
+    Name: z.string(),
+    ImageURL: z.string(),
+    TournamentIDs: z.array(z.string()),
+    TeamIDs: z.array(z.string()).nullable()
+})
+
+const tournamentSchema = z.object({
+    ID: z.string(),
+    Name: z.string(),
+    LeagueID: z.string(),
+    LeagueName: z.string(),
+    StartTime: z.string().describe('ISO 8601 date string'),
+    EndTime: z.string().describe('ISO 8601 date string'),
+    StageIDs: z.array(z.string()),
+    TeamIDs: z.array(z.string())
+})
+
+export const esportsUpcomingMatchesEndpoint = {
+    name: 'Upcoming Matches',
+    description: 'Get upcoming esports matches for VCT leagues. Returns leagues, tournaments, and teams data.',
+    queryName: 'Esports_GetUpcomingMatches',
+    category: 'Esports',
+    type: 'pd',
+    suffix: 'esports-service/v2/upcomingMatches',
+    riotRequirements: {
+        token: true,
+        entitlement: true
+    },
+    responses: {
+        '200': z.object({
+            Leagues: z.array(leagueSchema),
+            Tournaments: z.array(tournamentSchema),
+            Teams: z.array(teamSchema),
+            Seasons: z.null(),
+            Splits: z.null()
+        })
+    }
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/premier/PremierRosterMatchHistory.ts
+++ b/valorant-api-types/src/endpoints/premier/PremierRosterMatchHistory.ts
@@ -2,6 +2,33 @@ import {ValorantEndpoint} from '../../ValorantEndpoint'
 import {z} from 'zod'
 import {weakUUIDSchema} from '../../commonTypes'
 
+const leagueMatchEntrySchema = z.object({
+    matchId: weakUUIDSchema,
+    leaguePointsBefore: z.number(),
+    leaguePointsAfter: z.number(),
+    leaguePointsEarned: z.number(),
+    startTime: z.number().describe('Milliseconds since epoch')
+})
+
+const tournamentMatchDataEntrySchema = z.object({
+    points: z.number(),
+    roundNumber: z.number(),
+    totalRounds: z.number(),
+    bracketType: z.string().describe('e.g. "WINNERS", "LOSERS"')
+})
+
+const tournamentMatchEntrySchema = z.object({
+    tournamentId: weakUUIDSchema,
+    finalPlacement: z.number(),
+    finalPlacementLeaguePointsBonus: z.number(),
+    leaguePointsBefore: z.number(),
+    leaguePointsAfter: z.number(),
+    leaguePointsEarned: z.number(),
+    startTime: z.number().describe('Unix timestamp (seconds)'),
+    matchEntries: z.record(weakUUIDSchema, z.number()).describe('Map of match ID to score'),
+    tournamentMatchData: z.record(weakUUIDSchema, tournamentMatchDataEntrySchema)
+})
+
 export const premierRosterMatchHistoryEndpoint = {
     name: 'Premier Roster Match History',
     description: 'Get the Premier match history for a roster, split by league and tournament matches.',
@@ -18,8 +45,8 @@ export const premierRosterMatchHistoryEndpoint = {
     responses: {
         '200': z.object({
             id: weakUUIDSchema.describe('Roster ID'),
-            leagueMatchHistory: z.array(z.unknown()),
-            tournamentMatchHistory: z.array(z.unknown())
+            leagueMatchHistory: z.array(leagueMatchEntrySchema),
+            tournamentMatchHistory: z.array(tournamentMatchEntrySchema)
         })
     }
 } as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/premier/PremierRosterMatchHistory.ts
+++ b/valorant-api-types/src/endpoints/premier/PremierRosterMatchHistory.ts
@@ -35,7 +35,7 @@ export const premierRosterMatchHistoryEndpoint = {
     queryName: 'Premier_GetRosterMatchHistory',
     category: 'Premier',
     type: 'pd',
-    suffix: 'premier/v2/rosters/{rosterid}/matchhistory',
+    suffix: 'premier/v1/rosters/{rosterid}/matchhistory',
     riotRequirements: {
         token: true,
         entitlement: true,

--- a/valorant-api-types/src/endpoints/premier/PremierRosterPublicInfo.ts
+++ b/valorant-api-types/src/endpoints/premier/PremierRosterPublicInfo.ts
@@ -1,0 +1,95 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+import {weakUUIDSchema, playerUUIDSchema} from '../../commonTypes'
+
+const pointDeltasSchema = z.object({
+    before: z.number(),
+    after: z.number(),
+    earned: z.number()
+})
+
+const matchEntrySchema = z.object({
+    matchId: weakUUIDSchema,
+    seasonId: weakUUIDSchema,
+    eventId: weakUUIDSchema,
+    startTime: z.number().describe('Milliseconds since epoch'),
+    pointDeltas: pointDeltasSchema,
+    outcome: z.string().describe('e.g. "win", "loss"'),
+    opponentRosterID: weakUUIDSchema
+})
+
+const tournamentMatchDataSchema = z.object({
+    points: z.number(),
+    roundNumber: z.number(),
+    totalRounds: z.number(),
+    bracketType: z.string().describe('e.g. "WINNERS", "LOSERS"')
+})
+
+const tournamentEntrySchema = z.object({
+    tournamentId: weakUUIDSchema,
+    placement: z.number(),
+    startTime: z.number().describe('Unix timestamp (seconds)'),
+    pointDeltas: pointDeltasSchema,
+    matches: z.record(weakUUIDSchema, tournamentMatchDataSchema)
+})
+
+const seasonInfoSchema = z.object({
+    id: weakUUIDSchema,
+    isEnrolled: z.boolean(),
+    conference: z.string(),
+    division: z.number(),
+    isProvisionalDivision: z.boolean(),
+    promotionApplied: z.boolean(),
+    points: z.number(),
+    wins: z.number(),
+    gamesPlayed: z.number(),
+    seasonMatchRoundWins: z.number(),
+    seasonMatchRoundsPlayed: z.number(),
+    crest: z.string().describe('e.g. "NONE", "FIRST", "COMPETITOR"'),
+    plating: z.string().describe('e.g. "BASIC", "QUALIFIED"'),
+    matches: z.record(weakUUIDSchema, matchEntrySchema).optional(),
+    tournaments: z.record(weakUUIDSchema, tournamentEntrySchema).optional(),
+    hasEarnedPromotionForNextSeason: z.boolean(),
+    hasEarnedPrestige: z.boolean()
+})
+
+export const premierRosterPublicInfoEndpoint = {
+    name: 'Premier Roster Public Info',
+    description: 'Get public info for a Premier roster by roster ID, including members, customization, and detailed season match/tournament data.',
+    queryName: 'Premier_GetRosterPublicInfo',
+    category: 'Premier',
+    type: 'pd',
+    suffix: 'premier/v2/rosters/{rosterid}/publicInfo',
+    riotRequirements: {
+        token: true,
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
+    },
+    responses: {
+        '200': z.object({
+            rosterId: weakUUIDSchema,
+            name: z.string(),
+            tag: z.string(),
+            customization: z.object({
+                icon: weakUUIDSchema,
+                primaryColor: z.string().describe('Unreal Engine color string'),
+                secondaryColor: z.string(),
+                tertiaryColor: z.string()
+            }),
+            members: z.array(z.object({
+                puuid: playerUUIDSchema,
+                role: z.enum(['OWNER', 'MEMBER']),
+                roleId: z.number(),
+                createdAt: z.number().describe('Unix timestamp (seconds)')
+            })),
+            season: seasonInfoSchema,
+            version: z.object({
+                socialVersion: z.number(),
+                premierVersion: z.number()
+            }),
+            createdAt: z.number().describe('Unix timestamp (seconds)'),
+            seasonalInfoBySeasonID: z.record(weakUUIDSchema, seasonInfoSchema)
+        })
+    }
+} as const satisfies ValorantEndpoint

--- a/valorant-api-types/src/endpoints/premier/PremierRosterSetCustomization.ts
+++ b/valorant-api-types/src/endpoints/premier/PremierRosterSetCustomization.ts
@@ -3,7 +3,7 @@ import {z} from 'zod'
 import {weakUUIDSchema} from '../../commonTypes'
 
 export const premierRosterSetCustomizationEndpoint = {
-    name: 'Premier Roster Set Customization',
+    name: 'Premier Roster Customization',
     description: 'Set the customization (icon and colors) for a Premier roster.',
     queryName: 'Premier_SetRosterCustomization',
     category: 'Premier',

--- a/valorant-api-types/src/endpoints/premier/PremierRosterSetCustomization.ts
+++ b/valorant-api-types/src/endpoints/premier/PremierRosterSetCustomization.ts
@@ -1,0 +1,28 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+import {weakUUIDSchema} from '../../commonTypes'
+
+export const premierRosterSetCustomizationEndpoint = {
+    name: 'Premier Roster Set Customization',
+    description: 'Set the customization (icon and colors) for a Premier roster.',
+    queryName: 'Premier_SetRosterCustomization',
+    category: 'Premier',
+    type: 'pd',
+    method: 'PUT',
+    suffix: 'premier/v1/rosters/{rosterid}/customization',
+    riotRequirements: {
+        token: true,
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
+    },
+    body: z.object({
+        icon: weakUUIDSchema,
+        primaryColor: z.string().describe('Unreal Engine color string'),
+        secondaryColor: z.string(),
+        tertiaryColor: z.string()
+    }),
+    responses: {
+        '200': z.unknown()
+    }
+} as const satisfies ValorantEndpoint


### PR DESCRIPTION
## Summary

- Add new **Esports** category with two endpoints:
  - `GET esports-service/v2/upcomingMatches` — список предстоящих матчей VCT лиг (с обязательным `leagueID`, `locale`, `sport`)
  - `POST esports-service/v2/matches` — детали матчей по списку ID (`MATCHIDS`)
- Add **Premier** endpoints:
  - `GET premier/v1/rosters/{rosterid}/matchhistory` — история матчей ростера (лига + турниры), полная типизация вместо `z.unknown()`
  - `GET premier/v2/rosters/{rosterid}/publicInfo` — публичная информация о ростере с детальной историей матчей по сезонам
  - `PUT premier/v1/rosters/{rosterid}/customization` — установка кастомизации ростера (иконка, цвета)

## Test plan

- [ ] Убедиться что TypeScript компилируется без ошибок (`tsc --noEmit`)
- [ ] Проверить что все новые эндпоинты экспортируются из `endpoints.ts`
- [ ] Проверить соответствие схем реальным ответам API

https://claude.ai/code/session_01QxpULu8DGqYRi1jhMokSdc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxpULu8DGqYRi1jhMokSdc)_