### PR TITLE
Add Mailbox API endpoints for player mail management

### DIFF
--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -99,6 +99,9 @@ import {esportsMatchesEndpoint} from './endpoints/esports/EsportsMatches'
 import {premierRosterMatchHistoryEndpoint} from './endpoints/premier/PremierRosterMatchHistory'
 import {premierRosterPublicInfoEndpoint} from './endpoints/premier/PremierRosterPublicInfo'
 import {premierRosterSetCustomizationEndpoint} from './endpoints/premier/PremierRosterSetCustomization'
+import {mailboxEndpoint} from './endpoints/mailbox/Mailbox'
+import {mailEndpoint} from './endpoints/mailbox/Mail'
+import {deleteMailEndpoint} from './endpoints/mailbox/DeleteMail'
 
 export const endpoints = {
     fetchContentEndpoint,
@@ -175,6 +178,10 @@ export const endpoints = {
     premierRosterMatchHistoryEndpoint,
     premierRosterPublicInfoEndpoint,
     premierRosterSetCustomizationEndpoint,
+
+    mailboxEndpoint,
+    mailEndpoint,
+    deleteMailEndpoint,
 
     itemUpgradesEndpoint,
     contractsEndpoint,

--- a/valorant-api-types/src/endpoints/mailbox/DeleteMail.ts
+++ b/valorant-api-types/src/endpoints/mailbox/DeleteMail.ts
@@ -1,0 +1,26 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z, ZodType} from 'zod'
+import {playerUUIDSchema} from '../../commonTypes'
+import {mailIDSchema} from './Mailbox'
+
+export const deleteMailEndpoint = {
+    name: 'Delete Mail',
+    description: 'Delete a single mail by its ID. The mail no longer shows up in the [GET Mailbox] endpoint afterwards.',
+    category: 'Mailbox',
+    type: 'other',
+    method: 'DELETE',
+    suffix: 'https://{cluster}.pp.sgp.pvp.net/mailbox/v1/{puuid}/mail/{mail id}',
+    riotRequirements: {
+        token: true
+    },
+    variables: new Map<string, ZodType>([
+        ['cluster', z.string().describe('SGP region cluster, e.g. `euc-prod` for EU')],
+        ['puuid', playerUUIDSchema],
+        ['mail id', mailIDSchema.describe('The ID of the mail, obtained from the [GET Mailbox] endpoint')]
+    ]),
+    responses: {
+        '204': z.undefined()
+    }
+} as const satisfies ValorantEndpoint
+
+export type DeleteMailResponse = z.input<typeof deleteMailEndpoint.responses['204']>

--- a/valorant-api-types/src/endpoints/mailbox/Mail.ts
+++ b/valorant-api-types/src/endpoints/mailbox/Mail.ts
@@ -1,0 +1,25 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z, ZodType} from 'zod'
+import {playerUUIDSchema} from '../../commonTypes'
+import {mailIDSchema, mailSchema} from './Mailbox'
+
+export const mailEndpoint = {
+    name: 'Mail',
+    description: 'Get a single mail by its ID. The response is the same object as the entries of the [GET Mailbox] endpoint, just not wrapped in an array.',
+    category: 'Mailbox',
+    type: 'other',
+    suffix: 'https://{cluster}.pp.sgp.pvp.net/mailbox/v1/{puuid}/mail/{mail id}',
+    riotRequirements: {
+        token: true
+    },
+    variables: new Map<string, ZodType>([
+        ['cluster', z.string().describe('SGP region cluster, e.g. `euc-prod` for EU')],
+        ['puuid', playerUUIDSchema],
+        ['mail id', mailIDSchema.describe('The ID of the mail, obtained from the [GET Mailbox] endpoint')]
+    ]),
+    responses: {
+        '200': mailSchema
+    }
+} as const satisfies ValorantEndpoint
+
+export type MailResponse = z.input<typeof mailEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/mailbox/Mailbox.ts
+++ b/valorant-api-types/src/endpoints/mailbox/Mailbox.ts
@@ -1,0 +1,42 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z, ZodType} from 'zod'
+import {playerUUIDSchema, weakUUIDSchema} from '../../commonTypes'
+
+export const mailIDSchema = weakUUIDSchema.describe('Mail ID')
+
+export const mailSchema = z.object({
+    mailId: mailIDSchema,
+    puuid: playerUUIDSchema.describe('The player the mail was sent to'),
+    message: z.string().describe('JSON-encoded string with the contents of the mail. The keys depend on the type of mail, for example `{"product":"valorant","category":"COMMS_ABUSE_TEXT","recipientType":"","offenderRiotId":"name#tag"}`'),
+    product: z.string().describe('e.g. "valorant"'),
+    region: z.string().nullable(),
+    tags: z.array(z.string()).describe('e.g. `["ga-reporter-feedback-notification"]`'),
+    mailType: z.string().describe('e.g. "ACK_REQUIRED"'),
+    state: z.string().describe('e.g. "NEW", "READ", "ACKNOWLEDGED"'),
+    createdAt: z.number().describe('Milliseconds since epoch')
+})
+
+export const mailboxEndpoint = {
+    name: 'Mailbox',
+    description: 'Get the in-game mail of a player, such as the notifications sent after a report is acted on.\n\nThe `{cluster}` is the SGP cluster of the player\'s region and the `{puuid}` must be your own.',
+    category: 'Mailbox',
+    type: 'other',
+    suffix: 'https://{cluster}.pp.sgp.pvp.net/mailbox/v1/{puuid}/product/valorant',
+    riotRequirements: {
+        token: true
+    },
+    variables: new Map<string, ZodType>([
+        ['cluster', z.string().describe('SGP region cluster, e.g. `euc-prod` for EU')],
+        ['puuid', playerUUIDSchema]
+    ]),
+    query: new Map<string, ZodType>([
+        ['count', z.number().optional().describe('Maximum number of mails to return, e.g. `100`')],
+        ['startIndex', z.number().optional().describe('Index of the first mail to return, used together with `count` for pagination')],
+        ['includedStates', z.string().optional().describe('Only return mails in this state. Can be repeated to include multiple states, e.g. `includedStates=NEW&includedStates=READ&includedStates=ACKNOWLEDGED`. Observed values: `NEW`, `READ`, `ACKNOWLEDGED`')]
+    ]),
+    responses: {
+        '200': z.array(mailSchema)
+    }
+} as const satisfies ValorantEndpoint
+
+export type MailboxResponse = z.input<typeof mailboxEndpoint.responses['200']>

--- a/valorant-api-types/src/index.ts
+++ b/valorant-api-types/src/index.ts
@@ -106,6 +106,10 @@ export * from './endpoints/premier/PremierConferences'
 export * from './endpoints/premier/PremierRoster'
 export * from './endpoints/premier/PremierRosterMatchHistory'
 
+export * from './endpoints/mailbox/Mailbox'
+export * from './endpoints/mailbox/Mail'
+export * from './endpoints/mailbox/DeleteMail'
+
 export * from './endpoints'
 export * from './commonTypes'
 export * from './ValorantEndpoint'

--- a/valorant-api-types/tests/endpoint-responses/mailbox/reporter-feedback.json
+++ b/valorant-api-types/tests/endpoint-responses/mailbox/reporter-feedback.json
@@ -1,0 +1,13 @@
+[
+    {
+        "mailId": "facbd973-761f-4e5f-8ee6-c8e6e4e9d811",
+        "puuid": "ce586d80-382b-54a1-8e90-ef51153f8592",
+        "message": "{\"product\":\"valorant\",\"category\":\"COMMS_ABUSE_TEXT\",\"recipientType\":\"\",\"offenderRiotId\":\"mamkatvoya#08047\"}",
+        "product": "valorant",
+        "region": null,
+        "tags": ["ga-reporter-feedback-notification"],
+        "mailType": "ACK_REQUIRED",
+        "state": "ACKNOWLEDGED",
+        "createdAt": 1787817230000
+    }
+]


### PR DESCRIPTION
## Summary
This PR adds support for the Valorant Mailbox API, allowing users to retrieve, view, and delete in-game mail notifications such as report feedback.

## Key Changes
- **New Mailbox endpoint** (`GET /mailbox/v1/{puuid}/product/valorant`): Retrieve all mail for a player with optional filtering by state and pagination support
- **New Mail endpoint** (`GET /mailbox/v1/{puuid}/mail/{mail id}`): Retrieve a single mail by ID
- **New Delete Mail endpoint** (`DELETE /mailbox/v1/{puuid}/mail/{mail id}`): Delete a mail by ID
- Added comprehensive Zod schemas for mail objects and responses
- Exported all new endpoints and types from the main index
- Added test fixture with example reporter feedback notification

## Implementation Details
- All endpoints require authentication token and use the SGP cluster routing pattern
- Mail schema includes structured fields for mail metadata (ID, state, type, timestamps) and a JSON-encoded message field containing mail-specific content
- Mailbox endpoint supports query parameters for pagination (`count`, `startIndex`) and state filtering (`includedStates`)
- Response types are properly typed using Zod's `z.input` for type safety

https://claude.ai/code/session_01SHumBvQqZUngo4F4XjhmS8