### PR TITLE
Add Goldstars endpoints for medals and player statistics

### DIFF
--- a/valorant-api-types/src/endpoints.ts
+++ b/valorant-api-types/src/endpoints.ts
@@ -102,6 +102,8 @@ import {premierRosterSetCustomizationEndpoint} from './endpoints/premier/Premier
 import {mailboxEndpoint} from './endpoints/mailbox/Mailbox'
 import {mailEndpoint} from './endpoints/mailbox/Mail'
 import {deleteMailEndpoint} from './endpoints/mailbox/DeleteMail'
+import {goldstarsEndpoint} from './endpoints/goldstars/Goldstars'
+import {playerGoldstarsEndpoint} from './endpoints/goldstars/PlayerGoldstars'
 
 export const endpoints = {
     fetchContentEndpoint,
@@ -182,6 +184,9 @@ export const endpoints = {
     mailboxEndpoint,
     mailEndpoint,
     deleteMailEndpoint,
+
+    goldstarsEndpoint,
+    playerGoldstarsEndpoint,
 
     itemUpgradesEndpoint,
     contractsEndpoint,

--- a/valorant-api-types/src/endpoints/goldstars/Goldstars.ts
+++ b/valorant-api-types/src/endpoints/goldstars/Goldstars.ts
@@ -1,0 +1,30 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+import {weakUUIDSchema} from '../../commonTypes'
+
+export const goldstarIDSchema = weakUUIDSchema.describe('Goldstar ID')
+
+export const goldstarsEndpoint = {
+    name: 'Goldstars',
+    description: 'Get the list of all existing goldstars ("medals"), the awards shown after a match for stats such as kills, assists or headshot percentage.\n\n' +
+        'The list does not depend on the player and rarely changes, so it can be cached for a long time. ' +
+        'Riot does not return localized names or descriptions - the only name is the internal one in the obfuscated `tempT` field, ' +
+        'which has also been observed under the keys `displayName`, `name`, `title` and `devName` in different client builds.',
+    category: 'Goldstars',
+    type: 'pd',
+    suffix: 'goldstars/v1/goldstars',
+    riotRequirements: {
+        token: true,
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
+    },
+    responses: {
+        '200': z.array(z.object({
+            id: goldstarIDSchema,
+            tempT: z.string().describe('Internal (dev) name of the goldstar, e.g. `GoldStar_MostKills`')
+        }))
+    }
+} as const satisfies ValorantEndpoint
+
+export type GoldstarsResponse = z.input<typeof goldstarsEndpoint.responses['200']>

--- a/valorant-api-types/src/endpoints/goldstars/PlayerGoldstars.ts
+++ b/valorant-api-types/src/endpoints/goldstars/PlayerGoldstars.ts
@@ -1,0 +1,53 @@
+import {ValorantEndpoint} from '../../ValorantEndpoint'
+import {z} from 'zod'
+import {playerUUIDSchema, seasonIDSchema} from '../../commonTypes'
+import {goldstarIDSchema} from './Goldstars'
+
+export const playerGoldstarsEndpoint = {
+    name: 'Player Goldstars',
+    description: 'Get the goldstars ("medals") of a player: how often each goldstar was earned per act, the best value per act, and a breakdown of recent matches.\n\n' +
+        'Works for other players\' PUUIDs as well. The values change after every match, so only cache them briefly.\n\n' +
+        'The response keys are obfuscated and have changed between response versions (31 and 32 have been observed): in version 31 kills, assists and plants were sent per round, ' +
+        'in version 32 as the match total. To determine the unit of a goldstar, divide the real match total by the goldstar value - a result of about 1 means the goldstar is the match total, ' +
+        'a result close to the number of rounds means it is a per-round value. Values are float32, so numbers like `24.000001` are normal and should be rounded for display.\n\n' +
+        'The season ID `00000000-0000-0000-0000-000000000000` in `tempS` is not a real act but the all-time summary. ' +
+        'The `id` of a match is always an empty string, so the only link to the match history is the start time in `tempG` - ' +
+        'matching a match from the history with the closest entry in `tempM` within about ten minutes works in practice.\n\n' +
+        'For a player without any goldstars, `tempS` and `tempM` are empty. Matches in which no player earned a goldstar exist as well, in which case `tempP` is an empty object.',
+    category: 'Goldstars',
+    type: 'pd',
+    suffix: 'goldstars/v1/players/{puuid}',
+    riotRequirements: {
+        token: true,
+        entitlement: true,
+        clientPlatform: true,
+        clientVersion: true
+    },
+    responses: {
+        '200': z.object({
+            puuid: playerUUIDSchema,
+            version: z.number().describe('Version of the response format, 31 and 32 have been observed'),
+            tempS: z.record(seasonIDSchema, z.object({
+                tempS: seasonIDSchema.describe('Duplicate of the act ID'),
+                tempA: z.record(goldstarIDSchema, z.object({
+                    id: goldstarIDSchema,
+                    tempC: z.number().describe('How often the goldstar was earned during the act'),
+                    tempB: z.number().describe('Best value of the goldstar during the act')
+                })).describe('Goldstar ID to the summary of that goldstar for the act')
+            })).describe('Act ID to the summary of that act. The all-zero ID is the all-time summary instead of a real act'),
+            tempM: z.array(z.object({
+                id: z.string().describe('Always an empty string - the match ID is not returned'),
+                tempG: z.number().describe('Start time of the match in milliseconds since epoch'),
+                tempP: z.record(playerUUIDSchema, z.object({
+                    tempA: z.record(goldstarIDSchema, z.object({
+                        id: goldstarIDSchema,
+                        tempV: z.number().describe('Value of the goldstar in this match'),
+                        tempB: z.boolean().describe('Whether the value is a record for the act')
+                    })).describe('Goldstar ID to the value of that goldstar in this match')
+                })).describe('Player UUID to the goldstars of that player in this match. Contains all participants, not just the requested player')
+            })).describe('Recent matches with goldstars')
+        })
+    }
+} as const satisfies ValorantEndpoint
+
+export type PlayerGoldstarsResponse = z.input<typeof playerGoldstarsEndpoint.responses['200']>

--- a/valorant-api-types/src/index.ts
+++ b/valorant-api-types/src/index.ts
@@ -109,6 +109,8 @@ export * from './endpoints/premier/PremierRosterMatchHistory'
 export * from './endpoints/mailbox/Mailbox'
 export * from './endpoints/mailbox/Mail'
 export * from './endpoints/mailbox/DeleteMail'
+export * from './endpoints/goldstars/Goldstars'
+export * from './endpoints/goldstars/PlayerGoldstars'
 
 export * from './endpoints'
 export * from './commonTypes'


### PR DESCRIPTION
## Summary
This PR adds support for the Valorant Goldstars API endpoints, which provide access to in-game medals/awards data. Two new endpoints are introduced: one to fetch the list of all available goldstars, and another to retrieve a player's goldstar statistics and recent match performance.

## Key Changes
- **New Goldstars endpoint** (`goldstars/v1/goldstars`): Returns the list of all available goldstars with their internal names
- **New Player Goldstars endpoint** (`goldstars/v1/players/{puuid}`): Retrieves a player's goldstar statistics including:
  - Per-act goldstar summaries (count and best value)
  - Recent matches with goldstar values earned
  - All-time summary data
- **Schema definitions**: Added `goldstarIDSchema` for type safety
- **Exports**: Updated main index and endpoints files to export new types and endpoint definitions

## Notable Implementation Details
- Both endpoints require full authentication (token, entitlement, client platform, and version)
- Response format includes obfuscated field names (`tempS`, `tempA`, `tempC`, etc.) that may vary between API versions (31 and 32 observed)
- Comprehensive documentation included explaining data structure quirks, such as:
  - Match IDs always being empty strings (use timestamp matching instead)
  - All-zero season ID representing all-time summary
  - Float32 precision artifacts in values
  - Per-round vs. match-total value variations between response versions

https://claude.ai/code/session_01SAuu4cpnLiYbeMh1or5MGR