### PR TITLE
Document the known goldstar IDs

### DIFF
--- a/valorant-api-types/src/endpoints/goldstars/Goldstars.ts
+++ b/valorant-api-types/src/endpoints/goldstars/Goldstars.ts
@@ -9,7 +9,26 @@ export const goldstarsEndpoint = {
     description: 'Get the list of all existing goldstars ("medals"), the awards shown after a match for stats such as kills, assists or headshot percentage.\n\n' +
         'The list does not depend on the player and rarely changes, so it can be cached for a long time. ' +
         'Riot does not return localized names or descriptions - the only name is the internal one in the obfuscated `tempT` field, ' +
-        'which has also been observed under the keys `displayName`, `name`, `title` and `devName` in different client builds.',
+        'which has also been observed under the keys `displayName`, `name`, `title` and `devName` in different client builds.\n\n' +
+        'The meaning of a goldstar is not returned either. The IDs below were identified by comparing the values of the ' +
+        '[GET Player Goldstars] endpoint with the stats of the same matches from the [GET Match Details] endpoint:\n\n' +
+        '| Goldstar ID | Meaning |\n' +
+        '| --- | --- |\n' +
+        '| `6dc31cfd-41da-895f-9246-a8b63558cdb8` | Damage per round (ADR) |\n' +
+        '| `2c8b6129-4384-230d-c7e5-cda12019533c` | Headshot percentage of the match |\n' +
+        '| `1b13755f-4d5a-2c9e-6a39-bea7e6c53e7f` | Kills |\n' +
+        '| `1c926cba-48cb-8aeb-c68d-a1ba2d012784` | Kills (second ID with the same meaning) |\n' +
+        '| `e43f9acb-448c-4aa1-1591-6db72c0b8dae` | Assists |\n' +
+        '| `352a3ac8-4b2c-db6a-1f36-c0a67b428e65` | Spike plants |\n' +
+        '| `bfe96c47-44d0-e473-585d-749146d2d05e` | First kills |\n' +
+        '| `244cf4ab-4c27-cc59-3323-c985858d6ddb` | Aces |\n' +
+        '| `0497d585-42ad-61a7-42bc-189571f40e2c` | Clutches of 1v2 and higher |\n' +
+        '| `745b27f0-4bc2-13a4-4ee7-77be323155c2` | Unknown - a combined match rating capped at 500, awarded to exactly one player of the match |\n' +
+        '| `4815a8a2-4649-9bfe-afd2-38ae9cc22898` | Unknown - the same value as `745b27f0-4bc2-13a4-4ee7-77be323155c2`, but awarded to everyone above roughly 420 |\n' +
+        '| `3bc0563a-4fe9-a15c-0078-23a3408d64b5` | Unknown - an integer between 6 and 11 per match, awarded to several players at once |\n\n' +
+        'The three unknown values could not be reproduced from the data of the [GET Match Details] endpoint and are likely server-side stats that are not part of the match details. ' +
+        'Any other ID returned by this endpoint is unknown as well - note that the units of the identified goldstars are not fixed either, ' +
+        'see the [GET Player Goldstars] endpoint for how to determine them.',
     category: 'Goldstars',
     type: 'pd',
     suffix: 'goldstars/v1/goldstars',
@@ -21,7 +40,22 @@ export const goldstarsEndpoint = {
     },
     responses: {
         '200': z.array(z.object({
-            id: goldstarIDSchema,
+            id: goldstarIDSchema.describe(
+                'Goldstar ID. Known IDs:\n' +
+                '- `6dc31cfd-41da-895f-9246-a8b63558cdb8` - damage per round (ADR)\n' +
+                '- `2c8b6129-4384-230d-c7e5-cda12019533c` - headshot percentage of the match\n' +
+                '- `1b13755f-4d5a-2c9e-6a39-bea7e6c53e7f` - kills\n' +
+                '- `1c926cba-48cb-8aeb-c68d-a1ba2d012784` - kills (second ID with the same meaning)\n' +
+                '- `e43f9acb-448c-4aa1-1591-6db72c0b8dae` - assists\n' +
+                '- `352a3ac8-4b2c-db6a-1f36-c0a67b428e65` - spike plants\n' +
+                '- `bfe96c47-44d0-e473-585d-749146d2d05e` - first kills\n' +
+                '- `244cf4ab-4c27-cc59-3323-c985858d6ddb` - aces\n' +
+                '- `0497d585-42ad-61a7-42bc-189571f40e2c` - clutches of 1v2 and higher\n' +
+                '- `745b27f0-4bc2-13a4-4ee7-77be323155c2` - unknown, a combined match rating capped at 500, awarded to exactly one player of the match\n' +
+                '- `4815a8a2-4649-9bfe-afd2-38ae9cc22898` - unknown, the same value as `745b27f0-4bc2-13a4-4ee7-77be323155c2` but awarded to everyone above roughly 420\n' +
+                '- `3bc0563a-4fe9-a15c-0078-23a3408d64b5` - unknown, an integer between 6 and 11 per match, awarded to several players at once\n' +
+                '- any other ID - unknown'
+            ),
             tempT: z.string().describe('Internal (dev) name of the goldstar, e.g. `GoldStar_MostKills`')
         }))
     }

--- a/valorant-api-types/src/endpoints/goldstars/PlayerGoldstars.ts
+++ b/valorant-api-types/src/endpoints/goldstars/PlayerGoldstars.ts
@@ -13,6 +13,7 @@ export const playerGoldstarsEndpoint = {
         'The season ID `00000000-0000-0000-0000-000000000000` in `tempS` is not a real act but the all-time summary. ' +
         'The `id` of a match is always an empty string, so the only link to the match history is the start time in `tempG` - ' +
         'matching a match from the history with the closest entry in `tempM` within about ten minutes works in practice.\n\n' +
+        'The meaning of the goldstar IDs is listed in the [GET Goldstars] endpoint.\n\n' +
         'For a player without any goldstars, `tempS` and `tempM` are empty. Matches in which no player earned a goldstar exist as well, in which case `tempP` is an empty object.',
     category: 'Goldstars',
     type: 'pd',


### PR DESCRIPTION
## Summary
Follow-up to #21, which added the Goldstars endpoints without documenting what the individual goldstar IDs mean. This PR adds that mapping, identified by comparing the values of the Player Goldstars endpoint with the stats of the same matches from the Match Details endpoint.

## Key Changes
- **Markdown table in the `Goldstars` endpoint description** listing every observed goldstar ID and its meaning, so it renders on the endpoint page.
- **Doc comment on the `id` field** of the Goldstars response, so the same list shows up in the generated TypeScript type.
- **Cross-link** from the `Player Goldstars` description to the ID list.

## Identified IDs
Damage per round (ADR), headshot percentage, kills (two IDs with the same meaning), assists, spike plants, first kills, aces, and clutches of 1v2 and higher.

## Marked as unknown
Three IDs could not be reproduced from the match details and are listed as unknown together with what is known about them: a combined match rating capped at 500 awarded to exactly one player, the same value awarded to everyone above roughly 420, and an integer between 6 and 11 awarded to several players at once. Any other ID returned by the endpoint is marked unknown as well.

## Verification
`tsc --build` passes and the rendered type was checked with the same `zod-to-ts` call the docs site uses. Note that `npm test` in `valorant-api-types` already fails on `trunk` for an unrelated reason: a hoisted zod 3.25 in the workspace root breaks the `zod/lib/helpers/errorUtil` import in `tests/src/deepStrict.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAuu4cpnLiYbeMh1or5MGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAuu4cpnLiYbeMh1or5MGR)_